### PR TITLE
feat: 메트릭 정보 조회 기능 구현

### DIFF
--- a/server/src/main/java/org/server/core/metric/api/MetricApi.java
+++ b/server/src/main/java/org/server/core/metric/api/MetricApi.java
@@ -2,12 +2,15 @@ package org.server.core.metric.api;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.server.core.metric.api.payload.MetricGetRequest;
 import org.server.core.metric.api.payload.MetricInsertRequest;
+import org.server.core.metric.domain.ActiveTimeEntry;
 import org.server.core.metric.service.MetricService;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -21,5 +24,17 @@ public class MetricApi {
     public void insert(@RequestBody MetricInsertRequest request) {
         log.info("Insert metric: {}", request);
         metricService.save(request.userId(), request.toDomain(), request.toMetricMetadata());
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ActiveTimeEntry>> get(@RequestBody MetricGetRequest request) {
+        log.info("Get metric: {}", request);
+        List<ActiveTimeEntry> activeTime = metricService.find(request.userId(), request.term());
+
+        var response = ResponseEntity
+                .status(HttpStatus.OK)
+                .body(activeTime);
+
+        return response;
     }
 }

--- a/server/src/main/java/org/server/core/metric/api/payload/MetricGetRequest.java
+++ b/server/src/main/java/org/server/core/metric/api/payload/MetricGetRequest.java
@@ -1,0 +1,7 @@
+package org.server.core.metric.api.payload;
+
+public record MetricGetRequest(
+        Long userId,
+        String term
+) {
+}

--- a/server/src/main/java/org/server/core/metric/domain/ActiveTimeEntry.java
+++ b/server/src/main/java/org/server/core/metric/domain/ActiveTimeEntry.java
@@ -1,0 +1,17 @@
+package org.server.core.metric.domain;
+
+import org.server.core.site.domain.SiteDomain;
+
+public class ActiveTimeEntry {
+    private final SiteDomain siteDomain;
+    private final long duration;
+
+    public ActiveTimeEntry(SiteDomain siteDomain, long duration) {
+        this.siteDomain = siteDomain;
+        this.duration = duration;
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+}

--- a/server/src/main/java/org/server/core/metric/domain/MetricRepository.java
+++ b/server/src/main/java/org/server/core/metric/domain/MetricRepository.java
@@ -2,5 +2,9 @@ package org.server.core.metric.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
+import java.util.List;
+
 public interface MetricRepository extends JpaRepository<Metric, Long> {
+    List<Metric> findAllByMemberIdAndRequestAtAfter(long memberId, Instant requestAt);
 }

--- a/server/src/main/java/org/server/core/metric/service/MetricService.java
+++ b/server/src/main/java/org/server/core/metric/service/MetricService.java
@@ -1,14 +1,18 @@
 package org.server.core.metric.service;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import org.server.core.metric.domain.Domain;
-import org.server.core.metric.domain.Metric;
-import org.server.core.metric.domain.MetricMetadata;
-import org.server.core.metric.domain.MetricRepository;
+import org.server.core.metric.domain.*;
+import org.server.core.site.domain.SiteDomain;
 import org.server.core.site.domain.SiteDomainRepository;
 import org.server.core.site.infra.ExternalSiteClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
 
 @Service
 @Transactional
@@ -24,5 +28,75 @@ public class MetricService {
                 .orElseGet(() -> siteDomainRepository.save(externalSiteClient.getSiteDomain(domain)));
 
         metricRepository.save(new Metric(userId, siteDomain, metric));
+    }
+
+    public List<ActiveTimeEntry> find(Long userId, String term) {
+        LocalDateTime start = getStartTime(term);
+
+        List<Metric> userMetrics = metricRepository.findAllByMemberIdAndRequestAtAfter(userId, start.toInstant(ZoneOffset.of("+09:00")));
+        if (userMetrics.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<ActiveTimeEntry> activeTime = calculateActiveTime(userMetrics);
+
+        return activeTime;
+    }
+
+    public LocalDateTime getStartTime(String term) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime start = switch (term) {
+            case "day" -> // 지난 24시간이 아닌 당일 0시부터
+                    now.toLocalDate().atStartOfDay();
+            case "week" -> now.minusWeeks(1);
+            case "month" -> now.minusMonths(1);
+            default -> throw new IllegalArgumentException("Invalid time parameter : " + term);
+        };
+
+        return start;
+    }
+
+    public List<ActiveTimeEntry> calculateActiveTime(List<Metric> metrics) {
+        Map<SiteDomain, DomainTimeEntry> domainTime = new HashMap<>();
+
+        // 각 사이트 도메인별로 요청 시간을 계산
+        // path에 따라 요청 시간 계산 로직 추가 필요
+        for (Metric metric : metrics) {
+            SiteDomain siteDomain = metric.getSiteDomain();
+            LocalDateTime requestAt = LocalDateTime.ofInstant(metric.getMetadata().requestAt(), ZoneOffset.of("+09:00"));
+
+            domainTime.putIfAbsent(siteDomain, new DomainTimeEntry(requestAt, 0L));
+
+            long duration = java.time.Duration.between(domainTime.get(siteDomain).getRequestAt(), requestAt).toSeconds();
+            domainTime.get(siteDomain).addDuration(duration);
+            domainTime.get(siteDomain).setRequestAt(requestAt);
+        }
+
+        List<ActiveTimeEntry> activeTime = new ArrayList<>();
+        for (Map.Entry<SiteDomain, DomainTimeEntry> entry : domainTime.entrySet()) {
+            activeTime.add(new ActiveTimeEntry(entry.getKey(), entry.getValue().getDuration()));
+        }
+
+        return activeTime;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    private static class DomainTimeEntry {
+        private LocalDateTime requestAt;
+        private long duration;
+
+        public DomainTimeEntry(LocalDateTime requestAt, long duration) {
+            this.requestAt = requestAt;
+            this.duration = duration;
+        }
+
+        public void setRequestAt(LocalDateTime requestAt) {
+            this.requestAt = requestAt;
+        }
+
+        public void addDuration(long duration) {
+            this.duration += duration;
+        }
     }
 }

--- a/server/src/test/java/org/server/metric/api/GetByTimeServiceTests.java
+++ b/server/src/test/java/org/server/metric/api/GetByTimeServiceTests.java
@@ -1,0 +1,35 @@
+package org.server.metric.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class GetByTimeServiceTests {
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("Test getByTime API")
+    public void test() throws Exception {
+        // Given
+        String time = "day";
+        Integer id = 1;
+
+        // When
+        ResponseEntity<Object[]> response = restTemplate.getForEntity(
+                "/api/get-by-time?time=" + time + "&id=" + id,
+                Object[].class
+        );
+
+        // Then
+        assert response.getStatusCode().is2xxSuccessful();
+        assertThat(response.getBody()).containsExactly(time, id);
+    }
+
+}

--- a/server/src/test/java/org/server/metric/service/GetByTimeServiceTests.java
+++ b/server/src/test/java/org/server/metric/service/GetByTimeServiceTests.java
@@ -1,0 +1,6 @@
+package org.server.metric.service;
+
+
+public class GetByTimeServiceTests {
+
+}


### PR DESCRIPTION
* resolves: #1 

# 구현목록
<br>
* find 메서드로 DB에서 userId를 사용해 metric 정보를 조회
  * day, week, month를 query parameter로 사용
  * day의 경우 지난 24시간이 아닌 당일 0시 기준 누적 사용시간을 의미
* calculateAcitveTime 메서드를 사용해 각 도메인별 사용시간 계산
  * Map을 사용해서 domain/duration 형태로 계산 수행
  * 리스트 형태로 데이터 반환
  * ActiveTimeEntry 객체를 리스트 데이터로 사용
  * path를 포함한 url에 대한 사용시간 계산 로직 추가 필요